### PR TITLE
use older pyinstaller version to enable symlink

### DIFF
--- a/docker/Dockerfile-release.debian
+++ b/docker/Dockerfile-release.debian
@@ -7,6 +7,6 @@ WORKDIR /code
 
 RUN pwd
 
-RUN pip install -r requirements.txt && pip install pyinstaller
+RUN pip install -r requirements.txt && pip install pyinstaller===3.5
 
 ENTRYPOINT "docker/scripts/release.sh"


### PR DESCRIPTION
There seems to be an issue with symlinks in pyinstaller > 3.5
So here we revert back to 3.5 to get symlinks to work
We should go back to latest once this issue has been resolved, so this is temporary

https://github.com/pyinstaller/pyinstaller/issues/4674