### PR TITLE
do not report to backend before authentication

### DIFF
--- a/src/dg.py
+++ b/src/dg.py
@@ -315,7 +315,7 @@ def version():
 
 @cli.command()
 def auth():
-    report_async({"command": f"dg auth"}, status="start")    
+    # report_async({"command": f"dg auth"}, status="start")    
     fetch_github_token()
     report_async({"command": f"dg auth"}, status="complete")
 


### PR DESCRIPTION
the cli backend reporting endpoint required authentication, but we are not authenticated at `dg auth` call. Therefore we skip that particular reporting to avoid this type of annoying message on the screen:

![](https://i.imgur.com/ifqPngp.png)