### PR TITLE
relative imports to absolute imports

### DIFF
--- a/dg/api.py
+++ b/dg/api.py
@@ -1,9 +1,9 @@
 import requests
 from requests import Request, Session
-from .auth import get_github_token
-from .constants import BACKEND_ENDPOINT
-from .exceptions import ApiRequestException
-from .utils.pprint import Bcolors
+from dg.auth import get_github_token
+from dg.constants import BACKEND_ENDPOINT
+from dg.exceptions import ApiRequestException
+from dg.utils.pprint import Bcolors
 
 
 def do_api(method, endpoint, data, auth_token=None):

--- a/dg/auth.py
+++ b/dg/auth.py
@@ -3,8 +3,8 @@ import webbrowser
 import click
 import requests
 from functools import update_wrapper
-from .utils.pprint import Bcolors
-from .constants import (
+from dg.utils.pprint import Bcolors
+from dg.constants import (
     GITHUB_LOGIN_ENDPOINT,
     DIGGERTOKEN_FILE_PATH
 )

--- a/dg/dg.py
+++ b/dg/dg.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from collections import OrderedDict
 import subprocess
 from jinja2 import Template
-from .utils.pprint import Bcolors, Halo, spin
+from dg.utils.pprint import Bcolors, Halo, spin
 from oyaml import load as yload, dump as ydump
 try:
     from yaml import CLoader as Loader, CDumper as Dumper
@@ -27,12 +27,12 @@ except ImportError:
     import importlib_resources as pkg_resources
 
 from PyInquirer import prompt, Separator
-from . import api
-from .fileio import download_terraform_files
-from .auth import fetch_github_token, require_auth
-from .exceptions import CouldNotDetermineDockerLocation
-from ._version import __version__
-from .constants import (
+from dg import api
+from dg.fileio import download_terraform_files
+from dg.auth import fetch_github_token, require_auth
+from dg.exceptions import CouldNotDetermineDockerLocation
+from dg._version import __version__
+from dg.constants import (
     DIGGERHOME_PATH,
     BACKEND_ENDPOINT,
     GITHUB_LOGIN_ENDPOINT,

--- a/dg/fileio.py
+++ b/dg/fileio.py
@@ -4,7 +4,7 @@ import zipfile
 import time
 import requests
 import tempfile
-from . import api
+from dg import api
 
 
 def download_file(url, path):


### PR DESCRIPTION
To fix pyinstaller builds having relative imports issue:

`ImportError: attempted relative import with no known parent package`