### PR TITLE
stricter name validations in the cli

### DIFF
--- a/diggercli/transformers.py
+++ b/diggercli/transformers.py
@@ -1,0 +1,11 @@
+import re
+
+def transform_service_name(serviceName):
+    """
+        transforms an invalid service name into a valid one by capping length
+        and replacing all invalid characters
+    """
+    serviceName = re.sub(r"[\ \_]", "-", serviceName)
+    serviceName = serviceName.lower()
+    serviceName = serviceName[:10]
+    return serviceName

--- a/diggercli/validators.py
+++ b/diggercli/validators.py
@@ -1,0 +1,24 @@
+import re
+from PyInquirer import prompt, Validator, ValidationError
+from prompt_toolkit import document
+
+def project_name_validate(projectName):
+    if len(projectName) > 10:
+        raise ValueError('Project name should at most 10 characters')
+    ok=re.fullmatch(r'^[a-z\-]+$', projectName)
+    if not ok:
+        raise ValueError('Project name should only contain lowercase letters and hiphen (-)')
+
+class ProjectNameValidator(Validator):
+    def validate(self, document: document.Document) -> None:
+        try:
+            project_name_validate(document.text)
+        except ValueError as e:
+            raise ValidationError(message=str(e), cursor_position=len(document.text))
+
+def env_name_validate(envName):
+    if len(envName) > 10:
+        raise ValueError('Environment name should at most 10 characters')
+    ok=re.fullmatch(r'^[a-z\-]+$', envName)
+    if not ok:
+        raise ValueError('Environment name should only contain lowercase letters and hiphen (-)')

--- a/tst/test_validators.py
+++ b/tst/test_validators.py
@@ -1,0 +1,67 @@
+import unittest
+import os
+from unittest.mock import patch, MagicMock
+
+from diggercli import dg
+from diggercli.validators import (
+    project_name_validate,
+    env_name_validate
+)
+
+
+# TODO: parametarise tests
+class TestProjectValidator(unittest.TestCase):
+
+    def test_project_name_valid(self):
+        project_name_validate("iamvalid")
+
+    def test_project_name_valid2(self):
+        project_name_validate("exactlyten")
+
+    def test_project_name_valid4(self):
+        project_name_validate("hiphen-ok")
+
+    def test_project_name_invalid(self):
+        with self.assertRaises(ValueError) as context:
+            project_name_validate("cant contain spaces")
+
+    def test_project_name_invalid2(self):
+        with self.assertRaises(ValueError) as context:
+            project_name_validate("elevenexact")
+
+    def test_project_name_invalid3(self):
+        with self.assertRaises(ValueError) as context:
+            project_name_validate("@!@£sdf")
+
+    def test_project_name_invalid4(self):
+        with self.assertRaises(ValueError) as context:
+            project_name_validate("a1")
+
+
+# TODO: parametarise tests
+class TestEnvironmentValidator(unittest.TestCase):
+
+    def test_project_name_valid(self):
+        env_name_validate("iamvalid")
+
+    def test_project_name_valid2(self):
+        env_name_validate("exactlyten")
+
+    def test_project_name_valid4(self):
+        env_name_validate("hiphen-ok")
+
+    def test_project_name_invalid(self):
+        with self.assertRaises(ValueError) as context:
+            env_name_validate("cant contain spaces")
+
+    def test_project_name_invalid2(self):
+        with self.assertRaises(ValueError) as context:
+            env_name_validate("elevenexact")
+
+    def test_project_name_invalid3(self):
+        with self.assertRaises(ValueError) as context:
+            env_name_validate("@!@£sdf")
+
+    def test_project_name_invalid4(self):
+        with self.assertRaises(ValueError) as context:
+            env_name_validate("a1")


### PR DESCRIPTION
![](https://i.imgur.com/a7wUBkq.png)

Alot of resources on AWS are capped at 32 characters. Usually only lowercase and hiphens are allowed. To meet these requirements, we add the following restrictions:

- project name: lowercase or hiphen <= 10
- env name: lowercase or hiphen <= 10
- Service name: lowercase or hiphen, length is fine. BUT we replace any invalid characters and trim at the 10 char mark

Since the longest path we have is {projectname}-{envname}-{servicename},  above requirements cap to exactly 32 and all valid characters.